### PR TITLE
Add -Wall for GNU debug make build

### DIFF
--- a/conf/configure.fv3.cheyenne.gnu
+++ b/conf/configure.fv3.cheyenne.gnu
@@ -121,7 +121,7 @@ endif
 
 FFLAGS_OPT = -O2 -fno-range-check
 FFLAGS_REPRO = -O2 -g -fbacktrace -fno-range-check
-FFLAGS_DEBUG = -g -O0 -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -ffpe-trap=invalid,zero,overflow -fbounds-check -fbacktrace -fno-range-check
+FFLAGS_DEBUG = -g -O0 -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -ffpe-trap=invalid,zero,overflow -fbounds-check -fbacktrace -fno-range-check -Wall
 
 TRANSCENDENTALS :=
 FFLAGS_OPENMP = -fopenmp

--- a/conf/configure.fv3.linux.gnu
+++ b/conf/configure.fv3.linux.gnu
@@ -121,7 +121,7 @@ endif
 
 FFLAGS_OPT = -O2 -fno-range-check
 FFLAGS_REPRO = -O2 -g -fbacktrace -fno-range-check
-FFLAGS_DEBUG = -g -O0 -ggdb -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -ffpe-trap=invalid,zero,overflow -fbounds-check -fbacktrace -fno-range-check
+FFLAGS_DEBUG = -g -O0 -ggdb -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -ffpe-trap=invalid,zero,overflow -fbounds-check -fbacktrace -fno-range-check -Wall
 
 TRANSCENDENTALS :=
 FFLAGS_OPENMP = -fopenmp

--- a/conf/configure.fv3.macosx.gnu
+++ b/conf/configure.fv3.macosx.gnu
@@ -123,7 +123,7 @@ endif
 
 FFLAGS_OPT = -O2 -g -fno-range-check
 FFLAGS_REPRO = -O2 -g -fbacktrace -fno-range-check
-FFLAGS_DEBUG = -g -O0 -ggdb -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -Wuninitialized -ffpe-trap=invalid,zero,overflow -fbounds-check -fbacktrace -fno-range-check
+FFLAGS_DEBUG = -g -O0 -ggdb -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -Wuninitialized -ffpe-trap=invalid,zero,overflow -fbounds-check -fbacktrace -fno-range-check -Wall
 
 TRANSCENDENTALS :=
 FFLAGS_OPENMP = -fopenmp


### PR DESCRIPTION
For consistency with cmake/GNU.cmake, also add -Wall to GNU debug flags in `conf/configure.fv3.*.gnu`.

Compiles with old (make) and new (cmake) builds for CCPP static and dynamic (dynamic is only supported with old make build system), as well as IPD.