### PR TITLE
adding regional control back to jenkins-ci

### DIFF
--- a/tests/ci/Jenkinsfile
+++ b/tests/ci/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
                 axes {
                     axis {
                         name 'TEST_NAME'
-                        values 'control_p8', 'cpld_control_nowave_noaero_p8'
+                        values 'control_p8', 'regional_control', 'cpld_control_nowave_noaero_p8'
                     }
 
                     axis {
@@ -32,8 +32,17 @@ pipeline {
                         axis {
                             name 'TEST_CASE'
                             values 'mpi', 'dcp', 'bit', 'thr' // TODO: Remove thr case from cpld_control_nowave_noaero_p8 exclusions when it is passing again
-                        }
+                            }
                     }
+                    exclude {
+                        axis {
+                            name 'TEST_NAME'
+                            values 'regional_control'
+                        }
+
+                        axis {
+                            name 'TEST_CASE'
+                            values 'mpi', 'rst', 'bit', 'dbg'
                 }
 
                 agent {

--- a/tests/ci/ci.test
+++ b/tests/ci/ci.test
@@ -1,4 +1,6 @@
 control_p8
 thr mpi dcp rst bit dbg
+regional_control
+thr dcp
 cpld_control_nowave_noaero_p8
 rst dbg


### PR DESCRIPTION
## Description
<!--
Adding back regional_control case to jenkinsfile and ci.test. Setting the case to run dcp and thr operational requirement tests.
-->

### Top of commit queue on: TBD
<!-- Please have sub-component Code Managers ready for merging sub-component PR's on the date above and the day after the date above -->

### Input data additions/changes
- [ ] No changes are expected to input data.


### Anticipated changes to regression tests:
- [ ] No changes are expected to any regression test. 

## Subcomponents involved:
- [ ] AQM
- [ ] CDEPS
- [ ] CICE
- [ ] CMEPS
- [ ] CMakeModules
- [ ] FV3
- [ ] GOCART
- [ ] HYCOM
- [ ] MOM6
- [ ] NOAHMP
- [ ] WW3
- [ ] stochastic_physics
- [ ] none

### Combined with PR's (If Applicable):

## Commit Queue Checklist:
<!-- 
Please complete all items in list. Make sure to attach logs from RT testing in comment, not in repository. Once all boxes are checked, please add the label "Ready for Commit Queue".
-->
- [ ] Link PR's from all sub-components involved
- [ ] Confirm reviews completed in sub-component PR's
- [ ] Add all appropriate labels to this PR.
- [ ] Run full RT suite on either Hera/Cheyenne with both Intel/GNU compilers
- [ ] Add list of any failed regression tests to "Anticipated changes to regression tests" section.

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on NOAA-EMC/fv3atm/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes NOAA-EMC/fv3atm/issues/<issue_number>
-->

## Testing Day Checklist:
<!--
Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.
-->
- [ ] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.

### Testing Log (for CM's):
- RDHPCS
  - Intel
    - [ ] Hera
    - [ ] Orion
    - [ ] Jet
    - [ ] Gaea
    - [ ] Cheyenne
  - GNU
    - [ ] Hera
    - [ ] Cheyenne
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- CI
  - [ ] Completed
- opnReqTest
  - [ ] N/A
  - [ ] Log attached to comment
